### PR TITLE
multiple group metric options (sum, average, max, min, mode)

### DIFF
--- a/app/src/main/java/com/example/tracker/data/Counter.kt
+++ b/app/src/main/java/com/example/tracker/data/Counter.kt
@@ -3,6 +3,14 @@ package com.example.tracker.data
 import androidx.room.Entity
 import androidx.room.PrimaryKey
 
+enum class GroupMetric {
+    SUM,
+    AVERAGE,
+    MAXIMUM,
+    MINIMUM,
+    MODE
+}
+
 @Entity(tableName = "counter_lists")
 data class CounterList(
     @PrimaryKey val id: String = "",
@@ -25,7 +33,8 @@ data class CounterGroup(
     @PrimaryKey val id: String = "",
     val name: String = "Group",
     val colorValue: Long = 0L,
-    val listId: String = ""
+    val listId: String = "",
+    val metric: GroupMetric = GroupMetric.SUM
 )
 
 /** Stores the custom drag order as a comma-separated list of "g:<id>" / "c:<id>" keys, keyed by listId. */

--- a/app/src/main/java/com/example/tracker/data/TrackerDatabase.kt
+++ b/app/src/main/java/com/example/tracker/data/TrackerDatabase.kt
@@ -4,14 +4,25 @@ import android.content.Context
 import androidx.room.Database
 import androidx.room.Room
 import androidx.room.RoomDatabase
+import androidx.room.TypeConverter
+import androidx.room.TypeConverters
 import androidx.room.migration.Migration
 import androidx.sqlite.db.SupportSQLiteDatabase
 
+class Converters {
+    @TypeConverter
+    fun fromGroupMetric(metric: GroupMetric): String = metric.name
+
+    @TypeConverter
+    fun toGroupMetric(value: String): GroupMetric = GroupMetric.valueOf(value)
+}
+
 @Database(
     entities = [CounterList::class, Counter::class, CounterGroup::class, CustomOrderEntity::class],
-    version = 3,
+    version = 4,
     exportSchema = false
 )
+@TypeConverters(Converters::class)
 abstract class TrackerDatabase : RoomDatabase() {
     abstract fun counterListDao(): CounterListDao
     abstract fun counterDao(): CounterDao
@@ -54,13 +65,19 @@ abstract class TrackerDatabase : RoomDatabase() {
             }
         }
 
+        val MIGRATION_3_4 = object : Migration(3, 4) {
+            override fun migrate(database: SupportSQLiteDatabase) {
+                database.execSQL("ALTER TABLE `counter_groups` ADD COLUMN `metric` TEXT NOT NULL DEFAULT 'SUM'")
+            }
+        }
+
         fun getInstance(context: Context): TrackerDatabase =
             INSTANCE ?: synchronized(this) {
                 INSTANCE ?: Room.databaseBuilder(
                     context.applicationContext,
                     TrackerDatabase::class.java,
                     "tracker.db"
-                ).addMigrations(MIGRATION_1_2, MIGRATION_2_3).build().also { INSTANCE = it }
+                ).addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4).build().also { INSTANCE = it }
             }
     }
 }

--- a/app/src/main/java/com/example/tracker/ui/components/Dialogs.kt
+++ b/app/src/main/java/com/example/tracker/ui/components/Dialogs.kt
@@ -349,16 +349,15 @@ fun GroupSettingsDialog(
                     modifier = Modifier.fillMaxWidth(), singleLine = true)
 
                 // Metric dropdown
-                Text("Metric", style = MaterialTheme.typography.labelLarge)
                 ExposedDropdownMenuBox(
                     expanded = metricDropdownExpanded,
                     onExpandedChange = { metricDropdownExpanded = !metricDropdownExpanded },
                     modifier = Modifier.fillMaxWidth()
                 ) {
                     OutlinedTextField(
-                        value = metric.name,
+                        value = metric.name.lowercase().replaceFirstChar { it.uppercase() },
                         onValueChange = {},
-                        label = { Text("Select Metric") },
+                        label = { Text("Metric") },
                         readOnly = true,
                         trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = metricDropdownExpanded) },
                         modifier = Modifier
@@ -371,7 +370,7 @@ fun GroupSettingsDialog(
                     ) {
                         GroupMetric.values().forEach { metricOption ->
                             DropdownMenuItem(
-                                text = { Text(metricOption.name) },
+                                text = { Text(metricOption.name.lowercase().replaceFirstChar { it.uppercase() }) },
                                 onClick = {
                                     metric = metricOption
                                     metricDropdownExpanded = false

--- a/app/src/main/java/com/example/tracker/ui/components/Dialogs.kt
+++ b/app/src/main/java/com/example/tracker/ui/components/Dialogs.kt
@@ -56,6 +56,7 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
+import com.example.tracker.data.GroupMetric
 
 // ── Shared pastel colour palette ──────────────────────────────────────────────
 val colorOptions: List<Pair<String, Long>> = listOf(
@@ -283,13 +284,16 @@ fun CounterSettingsDialog(
 fun GroupSettingsDialog(
     groupName: String,
     groupColorValue: Long?,
+    groupMetric: GroupMetric = GroupMetric.SUM,
     onDismiss: () -> Unit,
-    onSave: (newName: String, newColor: Long?) -> Unit,
+    onSave: (newName: String, newColor: Long?, newMetric: GroupMetric) -> Unit,
     onDelete: () -> Unit,
 ) {
     var name  by remember { mutableStateOf(groupName) }
     var color by remember { mutableStateOf(groupColorValue) }
+    var metric by remember { mutableStateOf(groupMetric) }
     var showCustomPicker by remember { mutableStateOf(false) }
+    var metricDropdownExpanded by remember { mutableStateOf(false) }
 
     // Pre-compute whether current color is a palette color
     val isPaletteColor = color != null && colorOptions.any { it.second == color }
@@ -328,7 +332,7 @@ fun GroupSettingsDialog(
                     verticalAlignment = Alignment.CenterVertically
                 ) {
                     Button(
-                        onClick = { onSave(name.trim().ifBlank { groupName }, color) }
+                        onClick = { onSave(name.trim().ifBlank { groupName }, color, metric) }
                     ) { Text("Save") }
                 }
             }
@@ -343,6 +347,39 @@ fun GroupSettingsDialog(
             ) {
                 OutlinedTextField(value = name, onValueChange = { name = it }, label = { Text("Group Name") },
                     modifier = Modifier.fillMaxWidth(), singleLine = true)
+
+                // Metric dropdown
+                Text("Metric", style = MaterialTheme.typography.labelLarge)
+                ExposedDropdownMenuBox(
+                    expanded = metricDropdownExpanded,
+                    onExpandedChange = { metricDropdownExpanded = !metricDropdownExpanded },
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    OutlinedTextField(
+                        value = metric.name,
+                        onValueChange = {},
+                        label = { Text("Select Metric") },
+                        readOnly = true,
+                        trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = metricDropdownExpanded) },
+                        modifier = Modifier
+                            .menuAnchor(ExposedDropdownMenuAnchorType.PrimaryEditable)
+                            .fillMaxWidth()
+                    )
+                    ExposedDropdownMenu(
+                        expanded = metricDropdownExpanded,
+                        onDismissRequest = { metricDropdownExpanded = false }
+                    ) {
+                        GroupMetric.values().forEach { metricOption ->
+                            DropdownMenuItem(
+                                text = { Text(metricOption.name) },
+                                onClick = {
+                                    metric = metricOption
+                                    metricDropdownExpanded = false
+                                }
+                            )
+                        }
+                    }
+                }
 
                 Text("Color", style = MaterialTheme.typography.labelLarge)
 

--- a/app/src/main/java/com/example/tracker/ui/components/GroupCard.kt
+++ b/app/src/main/java/com/example/tracker/ui/components/GroupCard.kt
@@ -29,6 +29,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.example.tracker.data.Counter
 import com.example.tracker.data.CounterGroup
+import com.example.tracker.data.GroupMetric
 
 private fun Color.contrastTextColor(): Color {
     val luminance = 0.299f * red + 0.587f * green + 0.114f * blue
@@ -44,6 +45,21 @@ fun GroupCard(
     onDecrement: (String) -> Unit,
     onCounterClick: (String) -> Unit,
     groupExpandedState: MutableMap<String, Boolean>,
+    onCalculateMetric: (List<Counter>, GroupMetric) -> Double = { c, m ->
+        when (m) {
+            GroupMetric.SUM -> c.sumOf { it.value }.toDouble()
+            GroupMetric.AVERAGE -> if (c.isEmpty()) 0.0 else c.sumOf { it.value }.toDouble() / c.size
+            GroupMetric.MAXIMUM -> if (c.isEmpty()) 0.0 else c.maxOf { it.value }.toDouble()
+            GroupMetric.MINIMUM -> if (c.isEmpty()) 0.0 else c.minOf { it.value }.toDouble()
+            GroupMetric.MODE -> {
+                if (c.isEmpty()) 0.0
+                else {
+                    val counts = c.groupingBy { it.value }.eachCount()
+                    counts.maxByOrNull { it.value }?.key?.toDouble() ?: 0.0
+                }
+            }
+        }
+    },
     modifier: Modifier = Modifier,
     isDragging: Boolean = false,
     dragModifier: Modifier = Modifier
@@ -59,6 +75,21 @@ fun GroupCard(
     val titleColor = backgroundColor?.contrastTextColor() ?: MaterialTheme.colorScheme.onSurface
     val totalColor = if (backgroundColor != null) titleColor.copy(alpha = 0.85f)
         else MaterialTheme.colorScheme.onSurfaceVariant
+
+    // Calculate the metric value
+    val metricValue = onCalculateMetric(counters, group.metric)
+
+    // Format the metric display with up to 2 decimal places for non-integer values
+    val metricText = when (group.metric) {
+        GroupMetric.AVERAGE -> {
+            if (metricValue == metricValue.toInt().toDouble()) {
+                metricValue.toInt().toString()
+            } else {
+                String.format("%.2f", metricValue)
+            }
+        }
+        else -> metricValue.toInt().toString()
+    }
 
     val content: @Composable () -> Unit = {
         Column(
@@ -82,7 +113,7 @@ fun GroupCard(
                     modifier   = Modifier.weight(1f).clickable { onTitleClick() }
                 )
                 Text(
-                    text       = counters.sumOf { it.value }.toString(),
+                    text       = metricText,
                     style      = MaterialTheme.typography.titleLarge,
                     fontWeight = FontWeight.Bold,
                     color      = totalColor

--- a/app/src/main/java/com/example/tracker/ui/components/MainScreen.kt
+++ b/app/src/main/java/com/example/tracker/ui/components/MainScreen.kt
@@ -55,6 +55,7 @@ import android.provider.OpenableColumns
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import com.example.tracker.viewmodel.CounterViewModel
+import com.example.tracker.data.GroupMetric
 import java.io.File
 
 @Composable
@@ -371,10 +372,12 @@ fun MainScreen(viewModel: CounterViewModel, onNavigateToAbout: () -> Unit) {
         GroupSettingsDialog(
             groupName       = group.name,
             groupColorValue = group.colorValue.takeIf { it != 0L },
+            groupMetric     = group.metric,
             onDismiss       = { editingGroupId = null },
-            onSave          = { newName, newColor ->
+            onSave          = { newName, newColor, newMetric ->
                 viewModel.updateGroupName(gid, newName)
                 viewModel.updateGroupColor(gid, newColor)
+                viewModel.updateGroupMetric(gid, newMetric)
                 editingGroupId = null
             },
             onDelete = { viewModel.removeGroup(gid); editingGroupId = null }

--- a/app/src/main/java/com/example/tracker/viewmodel/CounterViewModel.kt
+++ b/app/src/main/java/com/example/tracker/viewmodel/CounterViewModel.kt
@@ -16,6 +16,7 @@ import com.example.tracker.data.Counter
 import com.example.tracker.data.CounterGroup
 import com.example.tracker.data.CounterList
 import com.example.tracker.data.CustomOrderEntity
+import com.example.tracker.data.GroupMetric
 import com.example.tracker.data.TrackerDatabase
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
@@ -510,6 +511,13 @@ class CounterViewModel(private val db: TrackerDatabase, context: Context) : View
         viewModelScope.launch { db.counterGroupDao().upsert(_groups[i]) }
     }
 
+    fun updateGroupMetric(groupId: String, metric: GroupMetric) {
+        val i = _groups.indexOfFirst { it.id == groupId }
+        if (i == -1) return
+        _groups[i] = _groups[i].copy(metric = metric)
+        viewModelScope.launch { db.counterGroupDao().upsert(_groups[i]) }
+    }
+
     // ── Export ────────────────────────────────────────────────────────────────
 
     fun buildCsvExport(): String {
@@ -620,25 +628,43 @@ class CounterViewModel(private val db: TrackerDatabase, context: Context) : View
         switchActiveList(list.id)
     }
 
-    /** RFC-4180-compliant CSV line splitter that handles quoted fields. */
-    private fun parseCsvLine(line: String): List<String> {
-        val fields = mutableListOf<String>()
-        val sb = StringBuilder()
-        var inQuotes = false
-        var i = 0
-        while (i < line.length) {
-            when {
-                line[i] == '"' && inQuotes && i + 1 < line.length && line[i + 1] == '"' -> {
-                    sb.append('"'); i += 2
-                }
-                line[i] == '"' -> { inQuotes = !inQuotes; i++ }
-                line[i] == ',' && !inQuotes -> { fields.add(sb.toString()); sb.clear(); i++ }
-                else -> { sb.append(line[i]); i++ }
-            }
-        }
-        fields.add(sb.toString())
-        return fields
-    }
+     /** RFC-4180-compliant CSV line splitter that handles quoted fields. */
+     private fun parseCsvLine(line: String): List<String> {
+         val fields = mutableListOf<String>()
+         val sb = StringBuilder()
+         var inQuotes = false
+         var i = 0
+         while (i < line.length) {
+             when {
+                 line[i] == '"' && inQuotes && i + 1 < line.length && line[i + 1] == '"' -> {
+                     sb.append('"'); i += 2
+                 }
+                 line[i] == '"' -> { inQuotes = !inQuotes; i++ }
+                 line[i] == ',' && !inQuotes -> { fields.add(sb.toString()); sb.clear(); i++ }
+                 else -> { sb.append(line[i]); i++ }
+             }
+         }
+         fields.add(sb.toString())
+         return fields
+     }
+
+     // ── Metric Calculations ────────────────────────────────────────────────────
+
+     fun calculateGroupMetric(counters: List<Counter>, metric: GroupMetric): Double {
+         return when (metric) {
+             GroupMetric.SUM -> counters.sumOf { it.value }.toDouble()
+             GroupMetric.AVERAGE -> if (counters.isEmpty()) 0.0 else counters.sumOf { it.value }.toDouble() / counters.size
+             GroupMetric.MAXIMUM -> if (counters.isEmpty()) 0.0 else counters.maxOf { it.value }.toDouble()
+             GroupMetric.MINIMUM -> if (counters.isEmpty()) 0.0 else counters.minOf { it.value }.toDouble()
+             GroupMetric.MODE -> {
+                 if (counters.isEmpty()) 0.0
+                 else {
+                     val counts = counters.groupingBy { it.value }.eachCount()
+                     counts.maxByOrNull { it.value }?.key?.toDouble() ?: 0.0
+                 }
+             }
+         }
+     }
 
     // ── Factory ───────────────────────────────────────────────────────────────
 

--- a/app/src/main/java/com/example/tracker/viewmodel/CounterViewModel.kt
+++ b/app/src/main/java/com/example/tracker/viewmodel/CounterViewModel.kt
@@ -301,23 +301,28 @@ class CounterViewModel(private val db: TrackerDatabase, context: Context) : View
         fun snapValue(counterId: String, live: Int) =
             _valueSortSnapshot.getOrDefault(counterId, live)
 
+        // Helper: calculate group metric value using snapped counter values for sorting
+        fun groupMetricForSort(group: CounterGroup): Double {
+            val countersInGroup = _counters.filter { it.groupId == group.id }
+            val snappedCounters = countersInGroup.map { it.copy(value = snapValue(it.id, it.value)) }
+            return calculateGroupMetric(snappedCounters, group.metric)
+        }
+
         return when (_sortOrder.value) {
             SortOrder.VALUE_HIGH_LOW -> all.sortedByDescending { item ->
                 when (item) {
                     is DisplayItem.Group ->
-                        _counters.filter { it.groupId == item.group.id }
-                                 .sumOf { snapValue(it.id, it.value) }
+                        groupMetricForSort(item.group)
                     is DisplayItem.UngroupedCounter ->
-                        snapValue(item.counter.id, item.counter.value)
+                        snapValue(item.counter.id, item.counter.value).toDouble()
                 }
             }
             SortOrder.VALUE_LOW_HIGH -> all.sortedBy { item ->
                 when (item) {
                     is DisplayItem.Group ->
-                        _counters.filter { it.groupId == item.group.id }
-                                 .sumOf { snapValue(it.id, it.value) }
+                        groupMetricForSort(item.group)
                     is DisplayItem.UngroupedCounter ->
-                        snapValue(item.counter.id, item.counter.value)
+                        snapValue(item.counter.id, item.counter.value).toDouble()
                 }
             }
             SortOrder.ALPHA_AZ -> all.sortedBy { item ->


### PR DESCRIPTION
### Summary
Closes #47 

- support different group summary metrics (sum, average, max, min, mode)
- selected in group settings dialog
- value sorting in list uses each group's metric instead of sum for all of them