### PR TITLE
add confirmation dialogs for major delete operations

### DIFF
--- a/app/src/main/java/com/example/tracker/ui/components/Dialogs.kt
+++ b/app/src/main/java/com/example/tracker/ui/components/Dialogs.kt
@@ -447,6 +447,7 @@ fun ListSettingsDialog(
     onDelete: () -> Unit,
 ) {
     var name by remember { mutableStateOf(listName) }
+    var showDeleteConfirm by remember { mutableStateOf(false) }
 
     Dialog(
         onDismissRequest = onDismiss,
@@ -465,7 +466,7 @@ fun ListSettingsDialog(
                     },
                     actions = {
                         if (!isOnlyList) {
-                            IconButton(onClick = onDelete) {
+                            IconButton(onClick = { showDeleteConfirm = true }) {
                                 Icon(
                                     imageVector = Icons.Outlined.Delete,
                                     contentDescription = "Delete List"
@@ -510,6 +511,24 @@ fun ListSettingsDialog(
                     Text("Export CSV")
                 }
             }
+        }
+
+        if (showDeleteConfirm) {
+            AlertDialog(
+                onDismissRequest = { showDeleteConfirm = false },
+                title = { Text("Are you sure?") },
+                confirmButton = {
+                    TextButton(onClick = {
+                        showDeleteConfirm = false
+                        onDelete()
+                    }) {
+                        Text("Delete", color = MaterialTheme.colorScheme.error)
+                    }
+                },
+                dismissButton = {
+                    TextButton(onClick = { showDeleteConfirm = false }) { Text("Cancel") }
+                }
+            )
         }
     }
 }

--- a/app/src/main/java/com/example/tracker/ui/components/Dialogs.kt
+++ b/app/src/main/java/com/example/tracker/ui/components/Dialogs.kt
@@ -89,10 +89,8 @@ fun ConfirmDeleteOverlay(
 ) {
     AnimatedVisibility(
         visible = visible,
-        enter = fadeIn(animationSpec = tween(160)) +
-                scaleIn(animationSpec = tween(180), initialScale = 0.96f),
-        exit  = fadeOut(animationSpec = tween(120)) +
-                scaleOut(animationSpec = tween(140), targetScale = 0.98f)
+        enter = fadeIn(animationSpec = tween(160)),
+        exit  = fadeOut(animationSpec = tween(120))
     ) {
         Box(
             modifier = Modifier
@@ -101,7 +99,14 @@ fun ConfirmDeleteOverlay(
                 .clickable { onDismiss() },
             contentAlignment = Alignment.Center
         ) {
-            Card(modifier = Modifier.padding(24.dp)) {
+            Card(
+                modifier = Modifier
+                    .padding(24.dp)
+                    .animateEnterExit(
+                        enter = scaleIn(animationSpec = tween(180), initialScale = 0.96f),
+                        exit  = scaleOut(animationSpec = tween(140), targetScale = 0.98f)
+                    )
+            ) {
                 Column(
                     modifier = Modifier.padding(20.dp),
                     verticalArrangement = Arrangement.spacedBy(16.dp)

--- a/app/src/main/java/com/example/tracker/ui/components/Dialogs.kt
+++ b/app/src/main/java/com/example/tracker/ui/components/Dialogs.kt
@@ -80,6 +80,55 @@ val colorOptions: List<Pair<String, Long>> = listOf(
     "Lavender"   to 0xFFCE93D8L,
 )
 
+// ── Reusable animated delete confirmation overlay ─────────────────────────────
+@Composable
+fun ConfirmDeleteOverlay(
+    visible: Boolean,
+    onDismiss: () -> Unit,
+    onConfirm: () -> Unit,
+) {
+    AnimatedVisibility(
+        visible = visible,
+        enter = fadeIn(animationSpec = tween(160)) +
+                scaleIn(animationSpec = tween(180), initialScale = 0.96f),
+        exit  = fadeOut(animationSpec = tween(120)) +
+                scaleOut(animationSpec = tween(140), targetScale = 0.98f)
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(Color.Black.copy(alpha = 0.32f))
+                .clickable { onDismiss() },
+            contentAlignment = Alignment.Center
+        ) {
+            Card(modifier = Modifier.padding(24.dp)) {
+                Column(
+                    modifier = Modifier.padding(20.dp),
+                    verticalArrangement = Arrangement.spacedBy(16.dp)
+                ) {
+                    Text(
+                        text = "Are you sure?",
+                        style = MaterialTheme.typography.titleLarge,
+                        textAlign = TextAlign.Start
+                    )
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.End
+                    ) {
+                        TextButton(onClick = { onDismiss() }) { Text("Cancel") }
+                        TextButton(onClick = {
+                            onDismiss()
+                            onConfirm()
+                        }) {
+                            Text("Delete", color = MaterialTheme.colorScheme.error)
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
 // ── Add counter ───────────────────────────────────────────────────────────────
 @Composable
 fun AddCounterDialog(onDismiss: () -> Unit, onAdd: (String) -> Unit) {
@@ -521,47 +570,11 @@ fun ListSettingsDialog(
             }
         }
 
-        AnimatedVisibility(
+        ConfirmDeleteOverlay(
             visible = showDeleteConfirm,
-            enter = fadeIn(animationSpec = tween(160)) +
-                    scaleIn(animationSpec = tween(180), initialScale = 0.96f),
-            exit = fadeOut(animationSpec = tween(120)) +
-                   scaleOut(animationSpec = tween(140), targetScale = 0.98f)
-        ) {
-            // Keep confirmation in the same window to avoid abrupt stacked-dialog transitions.
-            Box(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .background(Color.Black.copy(alpha = 0.32f))
-                    .clickable { showDeleteConfirm = false },
-                contentAlignment = Alignment.Center
-            ) {
-                Card(modifier = Modifier.padding(24.dp)) {
-                    Column(
-                        modifier = Modifier.padding(20.dp),
-                        verticalArrangement = Arrangement.spacedBy(16.dp)
-                    ) {
-                        Text(
-                            text = "Are you sure?",
-                            style = MaterialTheme.typography.titleLarge,
-                            textAlign = TextAlign.Start
-                        )
-                        Row(
-                            modifier = Modifier.fillMaxWidth(),
-                            horizontalArrangement = Arrangement.End
-                        ) {
-                            TextButton(onClick = { showDeleteConfirm = false }) { Text("Cancel") }
-                            TextButton(onClick = {
-                                showDeleteConfirm = false
-                                onDelete()
-                            }) {
-                                Text("Delete", color = MaterialTheme.colorScheme.error)
-                            }
-                        }
-                    }
-                }
-            }
-        }
+            onDismiss = { showDeleteConfirm = false },
+            onConfirm = onDelete
+        )
     }
 }
 

--- a/app/src/main/java/com/example/tracker/ui/components/Dialogs.kt
+++ b/app/src/main/java/com/example/tracker/ui/components/Dialogs.kt
@@ -1,5 +1,11 @@
 package com.example.tracker.ui.components
 
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.scaleIn
+import androidx.compose.animation.scaleOut
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -27,6 +33,7 @@ import androidx.compose.material.icons.filled.Palette
 import androidx.compose.material.icons.outlined.Delete
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
+import androidx.compose.material3.Card
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExposedDropdownMenuBox
@@ -53,6 +60,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
@@ -513,22 +521,46 @@ fun ListSettingsDialog(
             }
         }
 
-        if (showDeleteConfirm) {
-            AlertDialog(
-                onDismissRequest = { showDeleteConfirm = false },
-                title = { Text("Are you sure?") },
-                confirmButton = {
-                    TextButton(onClick = {
-                        showDeleteConfirm = false
-                        onDelete()
-                    }) {
-                        Text("Delete", color = MaterialTheme.colorScheme.error)
+        AnimatedVisibility(
+            visible = showDeleteConfirm,
+            enter = fadeIn(animationSpec = tween(160)) +
+                    scaleIn(animationSpec = tween(180), initialScale = 0.96f),
+            exit = fadeOut(animationSpec = tween(120)) +
+                   scaleOut(animationSpec = tween(140), targetScale = 0.98f)
+        ) {
+            // Keep confirmation in the same window to avoid abrupt stacked-dialog transitions.
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(Color.Black.copy(alpha = 0.32f))
+                    .clickable { showDeleteConfirm = false },
+                contentAlignment = Alignment.Center
+            ) {
+                Card(modifier = Modifier.padding(24.dp)) {
+                    Column(
+                        modifier = Modifier.padding(20.dp),
+                        verticalArrangement = Arrangement.spacedBy(16.dp)
+                    ) {
+                        Text(
+                            text = "Are you sure?",
+                            style = MaterialTheme.typography.titleLarge,
+                            textAlign = TextAlign.Start
+                        )
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalArrangement = Arrangement.End
+                        ) {
+                            TextButton(onClick = { showDeleteConfirm = false }) { Text("Cancel") }
+                            TextButton(onClick = {
+                                showDeleteConfirm = false
+                                onDelete()
+                            }) {
+                                Text("Delete", color = MaterialTheme.colorScheme.error)
+                            }
+                        }
                     }
-                },
-                dismissButton = {
-                    TextButton(onClick = { showDeleteConfirm = false }) { Text("Cancel") }
                 }
-            )
+            }
         }
     }
 }

--- a/app/src/main/java/com/example/tracker/ui/components/MainScreen.kt
+++ b/app/src/main/java/com/example/tracker/ui/components/MainScreen.kt
@@ -410,8 +410,7 @@ fun MainScreen(viewModel: CounterViewModel, onNavigateToAbout: () -> Unit) {
     if (confirmDeleteAllGroups) {
         AlertDialog(
             onDismissRequest = { confirmDeleteAllGroups = false },
-            title = { Text("Delete all groups?") },
-            text = { Text("This will remove all groups in the current list and move their counters to ungrouped.") },
+            title = { Text("Are you sure?") },
             confirmButton = {
                 TextButton(onClick = {
                     viewModel.groups
@@ -432,8 +431,7 @@ fun MainScreen(viewModel: CounterViewModel, onNavigateToAbout: () -> Unit) {
     if (confirmDeleteAllCounters) {
         AlertDialog(
             onDismissRequest = { confirmDeleteAllCounters = false },
-            title = { Text("Delete all counters?") },
-            text = { Text("This will permanently delete all counters in the current list.") },
+            title = { Text("Are you sure?") },
             confirmButton = {
                 TextButton(onClick = {
                     viewModel.removeAllCounters()
@@ -449,11 +447,9 @@ fun MainScreen(viewModel: CounterViewModel, onNavigateToAbout: () -> Unit) {
     }
 
     confirmDeleteListId?.let { listId ->
-        val listName = viewModel.lists.find { it.id == listId }?.name ?: "this list"
         AlertDialog(
             onDismissRequest = { confirmDeleteListId = null },
-            title = { Text("Delete list?") },
-            text = { Text("Delete \"$listName\" and all of its groups and counters?") },
+            title = { Text("Are you sure?") },
             confirmButton = {
                 TextButton(onClick = {
                     viewModel.removeList(listId)

--- a/app/src/main/java/com/example/tracker/ui/components/MainScreen.kt
+++ b/app/src/main/java/com/example/tracker/ui/components/MainScreen.kt
@@ -89,7 +89,6 @@ fun MainScreen(viewModel: CounterViewModel, onNavigateToAbout: () -> Unit) {
     var editingListId    by rememberSaveable { mutableStateOf<String?>(null) }
     var confirmDeleteAllGroups by rememberSaveable { mutableStateOf(false) }
     var confirmDeleteAllCounters by rememberSaveable { mutableStateOf(false) }
-    var confirmDeleteListId by rememberSaveable { mutableStateOf<String?>(null) }
 
     // Per-group expanded state: true = expanded (default), false = collapsed
     val groupExpandedState = remember { mutableStateMapOf<String, Boolean>() }
@@ -401,7 +400,7 @@ fun MainScreen(viewModel: CounterViewModel, onNavigateToAbout: () -> Unit) {
                 editingListId = null
             },
             onDelete    = {
-                confirmDeleteListId = lid
+                viewModel.removeList(lid)
                 editingListId = null
             }
         )
@@ -446,21 +445,4 @@ fun MainScreen(viewModel: CounterViewModel, onNavigateToAbout: () -> Unit) {
         )
     }
 
-    confirmDeleteListId?.let { listId ->
-        AlertDialog(
-            onDismissRequest = { confirmDeleteListId = null },
-            title = { Text("Are you sure?") },
-            confirmButton = {
-                TextButton(onClick = {
-                    viewModel.removeList(listId)
-                    confirmDeleteListId = null
-                }) {
-                    Text("Delete", color = MaterialTheme.colorScheme.error)
-                }
-            },
-            dismissButton = {
-                TextButton(onClick = { confirmDeleteListId = null }) { Text("Cancel") }
-            }
-        )
-    }
 }

--- a/app/src/main/java/com/example/tracker/ui/components/MainScreen.kt
+++ b/app/src/main/java/com/example/tracker/ui/components/MainScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.material.icons.filled.SwapVert
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -25,6 +26,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Tab
 import androidx.compose.material3.TabRowDefaults
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.TooltipAnchorPosition
 import androidx.compose.material3.TooltipBox
 import androidx.compose.material3.TooltipDefaults
@@ -85,6 +87,9 @@ fun MainScreen(viewModel: CounterViewModel, onNavigateToAbout: () -> Unit) {
     var editingCounterId by rememberSaveable { mutableStateOf<String?>(null) }
     var editingGroupId   by rememberSaveable { mutableStateOf<String?>(null) }
     var editingListId    by rememberSaveable { mutableStateOf<String?>(null) }
+    var confirmDeleteAllGroups by rememberSaveable { mutableStateOf(false) }
+    var confirmDeleteAllCounters by rememberSaveable { mutableStateOf(false) }
+    var confirmDeleteListId by rememberSaveable { mutableStateOf<String?>(null) }
 
     // Per-group expanded state: true = expanded (default), false = collapsed
     val groupExpandedState = remember { mutableStateMapOf<String, Boolean>() }
@@ -232,15 +237,15 @@ fun MainScreen(viewModel: CounterViewModel, onNavigateToAbout: () -> Unit) {
                                 text = { Text("Delete All Groups", color = MaterialTheme.colorScheme.error) },
                                 onClick = {
                                     showMenu = false
-                                    viewModel.groups
-                                        .filter { it.listId == activeListId }
-                                        .forEach { groupExpandedState.remove(it.id) }
-                                    viewModel.removeAllGroups()
+                                    confirmDeleteAllGroups = true
                                 }
                             )
                             DropdownMenuItem(
                                 text = { Text("Delete All Counters", color = MaterialTheme.colorScheme.error) },
-                                onClick = { showMenu = false; viewModel.removeAllCounters() }
+                                onClick = {
+                                    showMenu = false
+                                    confirmDeleteAllCounters = true
+                                }
                             )
                             DropdownMenuItem(text = { Text("About Tracker") }, onClick = { showMenu = false; onNavigateToAbout() })
                         }
@@ -396,8 +401,69 @@ fun MainScreen(viewModel: CounterViewModel, onNavigateToAbout: () -> Unit) {
                 editingListId = null
             },
             onDelete    = {
-                viewModel.removeList(lid)
+                confirmDeleteListId = lid
                 editingListId = null
+            }
+        )
+    }
+
+    if (confirmDeleteAllGroups) {
+        AlertDialog(
+            onDismissRequest = { confirmDeleteAllGroups = false },
+            title = { Text("Delete all groups?") },
+            text = { Text("This will remove all groups in the current list and move their counters to ungrouped.") },
+            confirmButton = {
+                TextButton(onClick = {
+                    viewModel.groups
+                        .filter { it.listId == activeListId }
+                        .forEach { groupExpandedState.remove(it.id) }
+                    viewModel.removeAllGroups()
+                    confirmDeleteAllGroups = false
+                }) {
+                    Text("Delete", color = MaterialTheme.colorScheme.error)
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { confirmDeleteAllGroups = false }) { Text("Cancel") }
+            }
+        )
+    }
+
+    if (confirmDeleteAllCounters) {
+        AlertDialog(
+            onDismissRequest = { confirmDeleteAllCounters = false },
+            title = { Text("Delete all counters?") },
+            text = { Text("This will permanently delete all counters in the current list.") },
+            confirmButton = {
+                TextButton(onClick = {
+                    viewModel.removeAllCounters()
+                    confirmDeleteAllCounters = false
+                }) {
+                    Text("Delete", color = MaterialTheme.colorScheme.error)
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { confirmDeleteAllCounters = false }) { Text("Cancel") }
+            }
+        )
+    }
+
+    confirmDeleteListId?.let { listId ->
+        val listName = viewModel.lists.find { it.id == listId }?.name ?: "this list"
+        AlertDialog(
+            onDismissRequest = { confirmDeleteListId = null },
+            title = { Text("Delete list?") },
+            text = { Text("Delete \"$listName\" and all of its groups and counters?") },
+            confirmButton = {
+                TextButton(onClick = {
+                    viewModel.removeList(listId)
+                    confirmDeleteListId = null
+                }) {
+                    Text("Delete", color = MaterialTheme.colorScheme.error)
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { confirmDeleteListId = null }) { Text("Cancel") }
             }
         )
     }

--- a/app/src/main/java/com/example/tracker/ui/components/MainScreen.kt
+++ b/app/src/main/java/com/example/tracker/ui/components/MainScreen.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -15,7 +16,6 @@ import androidx.compose.material.icons.filled.SwapVert
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -149,6 +149,7 @@ fun MainScreen(viewModel: CounterViewModel, onNavigateToAbout: () -> Unit) {
         } catch (_: Exception) { /* ignore read errors silently */ }
     }
 
+    Box(modifier = Modifier.fillMaxSize()) {
     Scaffold(
         modifier = Modifier.nestedScroll(topAppBarScrollBehavior.nestedScrollConnection),
         containerColor = MaterialTheme.colorScheme.background,
@@ -337,6 +338,25 @@ fun MainScreen(viewModel: CounterViewModel, onNavigateToAbout: () -> Unit) {
         )
     }
 
+    ConfirmDeleteOverlay(
+        visible = confirmDeleteAllGroups,
+        onDismiss = { confirmDeleteAllGroups = false },
+        onConfirm = {
+            viewModel.groups
+                .filter { it.listId == activeListId }
+                .forEach { groupExpandedState.remove(it.id) }
+            viewModel.removeAllGroups()
+        }
+    )
+
+    ConfirmDeleteOverlay(
+        visible = confirmDeleteAllCounters,
+        onDismiss = { confirmDeleteAllCounters = false },
+        onConfirm = { viewModel.removeAllCounters() }
+    )
+
+    } // end Box
+
     // ── Sort bottom sheet ─────────────────────────────────────────────────────
 
     if (showSortSheet) {
@@ -406,43 +426,5 @@ fun MainScreen(viewModel: CounterViewModel, onNavigateToAbout: () -> Unit) {
         )
     }
 
-    if (confirmDeleteAllGroups) {
-        AlertDialog(
-            onDismissRequest = { confirmDeleteAllGroups = false },
-            title = { Text("Are you sure?") },
-            confirmButton = {
-                TextButton(onClick = {
-                    viewModel.groups
-                        .filter { it.listId == activeListId }
-                        .forEach { groupExpandedState.remove(it.id) }
-                    viewModel.removeAllGroups()
-                    confirmDeleteAllGroups = false
-                }) {
-                    Text("Delete", color = MaterialTheme.colorScheme.error)
-                }
-            },
-            dismissButton = {
-                TextButton(onClick = { confirmDeleteAllGroups = false }) { Text("Cancel") }
-            }
-        )
-    }
-
-    if (confirmDeleteAllCounters) {
-        AlertDialog(
-            onDismissRequest = { confirmDeleteAllCounters = false },
-            title = { Text("Are you sure?") },
-            confirmButton = {
-                TextButton(onClick = {
-                    viewModel.removeAllCounters()
-                    confirmDeleteAllCounters = false
-                }) {
-                    Text("Delete", color = MaterialTheme.colorScheme.error)
-                }
-            },
-            dismissButton = {
-                TextButton(onClick = { confirmDeleteAllCounters = false }) { Text("Cancel") }
-            }
-        )
-    }
-
 }
+


### PR DESCRIPTION
### Summary
Closes #51 

- add dialogs for major delete operations
- delete all counters, delete all groups, and delete list
- dialog is done using animated card (not default material dialogs)