### PR TITLE
duplicate lists, groups, and counters

### DIFF
--- a/app/src/main/java/com/example/tracker/ui/components/Dialogs.kt
+++ b/app/src/main/java/com/example/tracker/ui/components/Dialogs.kt
@@ -30,6 +30,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.FormatColorReset
 import androidx.compose.material.icons.filled.Palette
+import androidx.compose.material.icons.outlined.ContentCopy
 import androidx.compose.material.icons.outlined.Delete
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
@@ -183,6 +184,7 @@ fun CounterSettingsDialog(
     currentColor: Long?,
     onDismiss: () -> Unit,
     onSave: (newName: String, newValue: Int, newGroupId: String?, newColor: Long?) -> Unit,
+    onDuplicate: () -> Unit,
     onDelete: () -> Unit,
 ) {
     var name  by remember { mutableStateOf(counterName) }
@@ -208,6 +210,12 @@ fun CounterSettingsDialog(
                         }
                     },
                     actions = {
+                        IconButton(onClick = onDuplicate) {
+                            Icon(
+                                imageVector = Icons.Outlined.ContentCopy,
+                                contentDescription = "Duplicate Counter"
+                            )
+                        }
                         IconButton(onClick = onDelete) {
                             Icon(
                                 imageVector = Icons.Outlined.Delete,
@@ -349,6 +357,7 @@ fun GroupSettingsDialog(
     groupMetric: GroupMetric = GroupMetric.SUM,
     onDismiss: () -> Unit,
     onSave: (newName: String, newColor: Long?, newMetric: GroupMetric) -> Unit,
+    onDuplicate: () -> Unit,
     onDelete: () -> Unit,
 ) {
     var name  by remember { mutableStateOf(groupName) }
@@ -376,6 +385,12 @@ fun GroupSettingsDialog(
                         }
                     },
                     actions = {
+                        IconButton(onClick = onDuplicate) {
+                            Icon(
+                                imageVector = Icons.Outlined.ContentCopy,
+                                contentDescription = "Duplicate Group"
+                            )
+                        }
                         IconButton(onClick = onDelete) {
                             Icon(
                                 imageVector = Icons.Outlined.Delete,
@@ -506,6 +521,7 @@ fun ListSettingsDialog(
     onDismiss: () -> Unit,
     onExportCsv: () -> Unit,
     onSave: (newName: String) -> Unit,
+    onDuplicate: () -> Unit,
     onDelete: () -> Unit,
 ) {
     var name by remember { mutableStateOf(listName) }
@@ -527,6 +543,12 @@ fun ListSettingsDialog(
                         }
                     },
                     actions = {
+                        IconButton(onClick = onDuplicate) {
+                            Icon(
+                                imageVector = Icons.Outlined.ContentCopy,
+                                contentDescription = "Duplicate List"
+                            )
+                        }
                         if (!isOnlyList) {
                             IconButton(onClick = { showDeleteConfirm = true }) {
                                 Icon(
@@ -694,4 +716,3 @@ private fun NoColorSwatch(selected: Boolean, onClick: () -> Unit) {
         )
     }
 }
-

--- a/app/src/main/java/com/example/tracker/ui/components/Dialogs.kt
+++ b/app/src/main/java/com/example/tracker/ui/components/Dialogs.kt
@@ -44,11 +44,16 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.PlainTooltip
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Slider
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
+import androidx.compose.material3.TooltipAnchorPosition
+import androidx.compose.material3.TooltipBox
+import androidx.compose.material3.TooltipDefaults
 import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.rememberTooltipState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
@@ -60,6 +65,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
@@ -210,18 +216,18 @@ fun CounterSettingsDialog(
                         }
                     },
                     actions = {
-                        IconButton(onClick = onDuplicate) {
-                            Icon(
-                                imageVector = Icons.Outlined.ContentCopy,
-                                contentDescription = "Duplicate Counter"
-                            )
-                        }
-                        IconButton(onClick = onDelete) {
-                            Icon(
-                                imageVector = Icons.Outlined.Delete,
-                                contentDescription = "Delete Counter"
-                            )
-                        }
+                        SettingsActionIconButton(
+                            tooltip = "Duplicate Counter",
+                            onClick = onDuplicate,
+                            imageVector = Icons.Outlined.ContentCopy,
+                            contentDescription = "Duplicate Counter"
+                        )
+                        SettingsActionIconButton(
+                            tooltip = "Delete Counter",
+                            onClick = onDelete,
+                            imageVector = Icons.Outlined.Delete,
+                            contentDescription = "Delete Counter"
+                        )
                     }
                 )
             },
@@ -385,18 +391,18 @@ fun GroupSettingsDialog(
                         }
                     },
                     actions = {
-                        IconButton(onClick = onDuplicate) {
-                            Icon(
-                                imageVector = Icons.Outlined.ContentCopy,
-                                contentDescription = "Duplicate Group"
-                            )
-                        }
-                        IconButton(onClick = onDelete) {
-                            Icon(
-                                imageVector = Icons.Outlined.Delete,
-                                contentDescription = "Delete Group"
-                            )
-                        }
+                        SettingsActionIconButton(
+                            tooltip = "Duplicate Group",
+                            onClick = onDuplicate,
+                            imageVector = Icons.Outlined.ContentCopy,
+                            contentDescription = "Duplicate Group"
+                        )
+                        SettingsActionIconButton(
+                            tooltip = "Delete Group",
+                            onClick = onDelete,
+                            imageVector = Icons.Outlined.Delete,
+                            contentDescription = "Delete Group"
+                        )
                     }
                 )
             },
@@ -543,19 +549,19 @@ fun ListSettingsDialog(
                         }
                     },
                     actions = {
-                        IconButton(onClick = onDuplicate) {
-                            Icon(
-                                imageVector = Icons.Outlined.ContentCopy,
-                                contentDescription = "Duplicate List"
-                            )
-                        }
+                        SettingsActionIconButton(
+                            tooltip = "Duplicate List",
+                            onClick = onDuplicate,
+                            imageVector = Icons.Outlined.ContentCopy,
+                            contentDescription = "Duplicate List"
+                        )
                         if (!isOnlyList) {
-                            IconButton(onClick = { showDeleteConfirm = true }) {
-                                Icon(
-                                    imageVector = Icons.Outlined.Delete,
-                                    contentDescription = "Delete List"
-                                )
-                            }
+                            SettingsActionIconButton(
+                                tooltip = "Delete List",
+                                onClick = { showDeleteConfirm = true },
+                                imageVector = Icons.Outlined.Delete,
+                                contentDescription = "Delete List"
+                            )
                         }
                     }
                 )
@@ -714,5 +720,26 @@ private fun NoColorSwatch(selected: Boolean, onClick: () -> Unit) {
             contentDescription = "No color",
             tint = MaterialTheme.colorScheme.onSurfaceVariant
         )
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun SettingsActionIconButton(
+    tooltip: String,
+    onClick: () -> Unit,
+    imageVector: ImageVector,
+    contentDescription: String,
+) {
+    TooltipBox(
+        positionProvider = TooltipDefaults.rememberTooltipPositionProvider(
+            positioning = TooltipAnchorPosition.Above
+        ),
+        tooltip = { PlainTooltip { Text(tooltip) } },
+        state = rememberTooltipState()
+    ) {
+        IconButton(onClick = onClick) {
+            Icon(imageVector = imageVector, contentDescription = contentDescription)
+        }
     }
 }

--- a/app/src/main/java/com/example/tracker/ui/components/MainScreen.kt
+++ b/app/src/main/java/com/example/tracker/ui/components/MainScreen.kt
@@ -428,6 +428,15 @@ fun MainScreen(viewModel: CounterViewModel, onNavigateToAbout: () -> Unit) {
                 viewModel.updateCounterColor(cid, newColor)
                 editingCounterId = null
             },
+            onDuplicate = {
+                val duplicatedId = viewModel.duplicateCounter(cid)
+                if (duplicatedId != null) {
+                    editingCounterId = null
+                    coroutineScope.launch {
+                        snackbarHostState.showSnackbar("Duplicated counter: ${counter.name}")
+                    }
+                }
+            },
             onDelete = {
                 viewModel.removeCounter(cid)
                 editingCounterId = null
@@ -451,6 +460,15 @@ fun MainScreen(viewModel: CounterViewModel, onNavigateToAbout: () -> Unit) {
                 viewModel.updateGroupMetric(gid, newMetric)
                 editingGroupId = null
             },
+            onDuplicate = {
+                val duplicatedId = viewModel.duplicateGroup(gid)
+                if (duplicatedId != null) {
+                    editingGroupId = null
+                    coroutineScope.launch {
+                        snackbarHostState.showSnackbar("Duplicated group: ${group.name}")
+                    }
+                }
+            },
             onDelete = {
                 viewModel.removeGroup(gid)
                 editingGroupId = null
@@ -472,6 +490,15 @@ fun MainScreen(viewModel: CounterViewModel, onNavigateToAbout: () -> Unit) {
                 viewModel.renameList(lid, newName)
                 editingListId = null
             },
+            onDuplicate = {
+                val duplicatedId = viewModel.duplicateList(lid)
+                if (duplicatedId != null) {
+                    editingListId = null
+                    coroutineScope.launch {
+                        snackbarHostState.showSnackbar("Duplicated list: ${list.name}")
+                    }
+                }
+            },
             onDelete    = {
                 val deletedListName = list.name
                 viewModel.removeList(lid)
@@ -484,4 +511,3 @@ fun MainScreen(viewModel: CounterViewModel, onNavigateToAbout: () -> Unit) {
     }
 
 }
-

--- a/app/src/main/java/com/example/tracker/viewmodel/CounterViewModel.kt
+++ b/app/src/main/java/com/example/tracker/viewmodel/CounterViewModel.kt
@@ -239,6 +239,93 @@ class CounterViewModel(private val db: TrackerDatabase, context: Context) : View
         }
     }
 
+    fun duplicateList(listId: String): String? {
+        val sourceList = _lists.find { it.id == listId } ?: return null
+        listSequence++
+
+        val duplicatedList = CounterList(
+            id = UUID.randomUUID().toString(),
+            name = sourceList.name,
+            position = _lists.size
+        )
+
+        val sourceGroups = _groups.filter { it.listId == listId }
+        val sourceCounters = _counters.filter { it.listId == listId }
+
+        val groupIdMap = HashMap<String, String>(sourceGroups.size)
+        val duplicatedGroups = sourceGroups.map { group ->
+            val newGroupId = UUID.randomUUID().toString()
+            groupIdMap[group.id] = newGroupId
+            group.copy(id = newGroupId, listId = duplicatedList.id)
+        }
+
+        val duplicatedCounters = sourceCounters.map { counter ->
+            counter.copy(
+                id = UUID.randomUUID().toString(),
+                listId = duplicatedList.id,
+                groupId = counter.groupId?.let { groupIdMap[it] }
+            )
+        }
+
+        val counterIdMap = sourceCounters.zip(duplicatedCounters).associate { (source, duplicated) ->
+            source.id to duplicated.id
+        }
+
+        groupSequence += duplicatedGroups.size
+        counterSequence += duplicatedCounters.size
+
+        val sourceOrder = if (listId == _activeListId.value) {
+            _customOrder.toList()
+        } else {
+            _customOrderCache[listId]?.toList().orEmpty()
+        }
+
+        val tokenMap = buildMap {
+            sourceGroups.forEachIndexed { index, group ->
+                put("g:${group.id}", "g:${duplicatedGroups[index].id}")
+            }
+            sourceCounters
+                .filter { it.groupId == null }
+                .forEach { sourceCounter ->
+                    val duplicatedCounterId = counterIdMap[sourceCounter.id] ?: return@forEach
+                    put("c:${sourceCounter.id}", "c:$duplicatedCounterId")
+                }
+        }
+
+        val duplicatedOrder = mutableListOf<String>()
+        sourceOrder.forEach { token ->
+            tokenMap[token]?.let { mapped ->
+                if (mapped !in duplicatedOrder) duplicatedOrder.add(mapped)
+            }
+        }
+
+        val fallbackOrderTokens = sourceGroups.map { "g:${it.id}" } +
+            sourceCounters.filter { it.groupId == null }.map { "c:${it.id}" }
+        fallbackOrderTokens.forEach { token ->
+            val mapped = tokenMap[token] ?: return@forEach
+            if (mapped !in duplicatedOrder) duplicatedOrder.add(mapped)
+        }
+
+        _lists.add(duplicatedList)
+        _groups.addAll(duplicatedGroups)
+        _counters.addAll(duplicatedCounters)
+        _customOrderCache[duplicatedList.id] = duplicatedOrder.toMutableList()
+
+        viewModelScope.launch {
+            db.counterListDao().upsert(duplicatedList)
+            duplicatedGroups.forEach { db.counterGroupDao().upsert(it) }
+            duplicatedCounters.forEach { db.counterDao().upsert(it) }
+            db.customOrderDao().saveOrder(
+                CustomOrderEntity(
+                    listId = duplicatedList.id,
+                    order = duplicatedOrder.joinToString(",")
+                )
+            )
+        }
+
+        return duplicatedList.id
+    }
+
     /**
      * Switch the active list. Saves the current list's order to the cache,
      * then loads the target list's order into _customOrder.
@@ -443,6 +530,23 @@ class CounterViewModel(private val db: TrackerDatabase, context: Context) : View
         viewModelScope.launch { db.counterDao().upsert(_counters[i]) }
     }
 
+    fun duplicateCounter(counterId: String): String? {
+        val sourceCounter = _counters.find { it.id == counterId } ?: return null
+        val duplicatedCounter = sourceCounter.copy(id = UUID.randomUUID().toString())
+
+        counterSequence++
+        _counters.add(duplicatedCounter)
+
+        if (duplicatedCounter.groupId == null && duplicatedCounter.listId == _activeListId.value) {
+            _customOrder.add("c:${duplicatedCounter.id}")
+            saveOrder()
+            _lastAddedKey.value = "c:${duplicatedCounter.id}"
+        }
+
+        viewModelScope.launch { db.counterDao().upsert(duplicatedCounter) }
+        return duplicatedCounter.id
+    }
+
     // ── Group CRUD ────────────────────────────────────────────────────────────
 
     fun addGroup(name: String? = null, colorValue: Long? = null) {
@@ -456,6 +560,35 @@ class CounterViewModel(private val db: TrackerDatabase, context: Context) : View
         saveOrder()
         _lastAddedKey.value = "g:${group.id}"
         viewModelScope.launch { db.counterGroupDao().upsert(group) }
+    }
+
+    fun duplicateGroup(groupId: String): String? {
+        val sourceGroup = _groups.find { it.id == groupId } ?: return null
+        val countersInGroup = _counters.filter { it.groupId == groupId }
+
+        val duplicatedGroup = sourceGroup.copy(id = UUID.randomUUID().toString())
+        val duplicatedCounters = countersInGroup.map { counter ->
+            counter.copy(id = UUID.randomUUID().toString(), groupId = duplicatedGroup.id)
+        }
+
+        groupSequence++
+        counterSequence += duplicatedCounters.size
+
+        _groups.add(duplicatedGroup)
+        _counters.addAll(duplicatedCounters)
+
+        if (duplicatedGroup.listId == _activeListId.value) {
+            _customOrder.add("g:${duplicatedGroup.id}")
+            saveOrder()
+            _lastAddedKey.value = "g:${duplicatedGroup.id}"
+        }
+
+        viewModelScope.launch {
+            db.counterGroupDao().upsert(duplicatedGroup)
+            duplicatedCounters.forEach { db.counterDao().upsert(it) }
+        }
+
+        return duplicatedGroup.id
     }
 
     fun removeGroup(groupId: String) {
@@ -679,3 +812,4 @@ class CounterViewModel(private val db: TrackerDatabase, context: Context) : View
             CounterViewModel(db, context) as T
     }
 }
+


### PR DESCRIPTION
### Summary
Closes #33 

- add support for duplicating lists, groups, and counters
- LIST: counters and groups + colors, list name
- GROUP: counters in group, group color + name + metric
- COUNTER: counter name + color, group if assigned
- tooltips in settings dialogs icons buttons